### PR TITLE
Allow application to provide httpd.conf file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ source "$BUILDPACK_HOME/bin/common.sh"
 trap build_failed ERR # Provide hook to deal with errors
 
 if [ -f "$BUILD_DIR/.apache/.apache.cfg" ]; then
-	info "Found $BUILD_DIR/.apache/.apache.cfg" 
+	info "Found $BUILD_DIR/.apache/.apache.cfg"
 	source "$BUILD_DIR/.apache/.apache.cfg"
 fi
 
@@ -113,8 +113,13 @@ fi
 info "Copying Apache $APACHE_VERSION into $BUILD_DIR ..."
 cp -R "$CACHE_DIR/apache" "$BUILD_DIR"
 
-info "Installing configuration files..."
-cp "$BUILDPACK_HOME/config/httpd.conf" $BUILD_DIR/apache/etc/apache2
+if [ -f "$BUILD_DIR/httpd.conf" ]; then
+	info "Using application configuration files..."
+	cp "$BUILD_DIR/httpd.conf" $BUILD_DIR/apache/etc/apache2
+else
+	info "Installing configuration files..."
+	cp "$BUILDPACK_HOME/config/httpd.conf" $BUILD_DIR/apache/etc/apache2
+fi
 
 info "Installing startup script..."
 cp "$BUILDPACK_HOME/bin/boot.sh" $BUILD_DIR


### PR DESCRIPTION
Provide ability for consuming application t provide the `httpd.conf` file to use instead of the one provided by the buildpack.